### PR TITLE
Fix 2 errors in quickstart example code

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Flask-BrowserID requires that Flask-Login's LoginManager be configured and regis
 
     from flask import Flask
     from flask.ext.login import LoginManager
-    from flask.ext.login import BrowserID
+    from flask.ext.browserid import BrowserID
     from my_stuff import get_user_by_id # finds a user by their id
     from other_stuff import get_user # finds a user based on BrowserID response
 
@@ -31,7 +31,7 @@ Flask-BrowserID requires that Flask-Login's LoginManager be configured and regis
     
     login_manager = LoginManager()
     login_manager.user_loader(get_user_by_id)
-    login_manager.init_app(app)
+    login_manager.setup_app(app)
 
     browser_id = BrowserID()
     browser_id.user_loader(get_user)


### PR DESCRIPTION
1) BrowserID should be imported from flask.ext.browserid, not flask.ext.login. (Closes #10)

2) The LoginManager class has a setup_app method, not init_app
