### PR TITLE
Fix a function has no attribute "read" error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='Flask-BrowserID',
-    version='0.0.1',
+    version='0.0.2',
     url='https://github.com/garbados/flask-browserid',
     license='MIT',
     author='Max Thayer',


### PR DESCRIPTION
On at least Python2.7, I can't install this as a dependency in another setup.py
because it fails with:
`AttributeError: 'function' object has no attribute 'read'`

I'm not sure if this breaks other versions or if it's just something in my setup, but it scratches my itch.
