### PR TITLE
Add BROWSERID_CLIENT_SCHEME option

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,8 +84,15 @@ Optional Configuration
 
 You can set the URLs Flask-BrowserID uses for login and logout by setting the following in your application's configuration:
 
-* `BROWSERID_LOGIN_URL`: defaults to `/api/login`
-* `BROWSERID_LOGOUT_URL`: defaults to `/api/logout`
+* `BROWSERID_LOGIN_URL`: defaults to ``/api/login``
+* `BROWSERID_LOGOUT_URL`: defaults to ``/api/logout``
+
+You can override the domain name and `scheme <http://en.wikipedia.org/wiki/URI_scheme>`_ for cases where the URL that the user browses to differs from the url of the server for example when you have a `reverse proxy <http://en.wikipedia.org/wiki/Reverse_proxy>`_
+
+* `BROWSERID_CLIENT_DOMAIN`: override the DNS name of the site. Example : ``example.com``
+* `BROWSERID_CLIENT_SCHEME`: override the scheme of the site (e.g. http vs https). Example : ``https``
+
+By default each of these values are determined by `flask.request.url_root <http://flask.pocoo.org/docs/0.10/api/#flask.Request.url_root>`_
 
 See `Flask Configuration Handling
 <http://flask.pocoo.org/docs/config/>`_ for more on how to configure your application.

--- a/flaskext/browserid/__init__.py
+++ b/flaskext/browserid/__init__.py
@@ -25,6 +25,7 @@ class BrowserID(object):
         self.login_url = app.config.get('BROWSERID_LOGIN_URL', '/api/login')
         self.logout_url = app.config.get('BROWSERID_LOGOUT_URL', '/api/logout')
         self.client_domain = app.config.get('BROWSERID_CLIENT_DOMAIN', None)
+        self.client_scheme = app.config.get('BROWSERID_CLIENT_SCHEME', None)
 
         if not self.login_callback:
             if app.config.get('BROWSERID_LOGIN_CALLBACK'):
@@ -73,6 +74,8 @@ class BrowserID(object):
     def get_client_origin(self):
         if self.client_domain:
             # Build the client_origin
+            if self.client_scheme:
+                return self.client_scheme + '://' + self.client_domain
             end_scheme = flask.request.url_root.find('://') + 3
             client_scheme = flask.request.url_root[:end_scheme]
             return client_scheme + self.client_domain


### PR DESCRIPTION
If you use `flask-browserid` on a server which has a reverse proxy in front of it (for example flask sitting behind nginx or apache), and the flask process is listening on `http` but the reverse proxy is listening on `https`, `flask-browserid` gets the assertion audience wrong resulting in failed Persona verification.

This adds an option to allow for setting the scheme (much like the domain name can be configured) to accommodate situations like this.

I've also added documentation for this and the existing `BROWSERID_CLIENT_DOMAIN` option.
